### PR TITLE
add phpmentors into Other Github organisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Other Github organisations
 
 - https://github.com/dddinphp
 - https://github.com/orgs/ddd-php
+- https://github.com/phpmentors-jp
 
 On Discussion Groups
 ----------------


### PR DESCRIPTION
PHP mentors is working active around DDD & PHP in Japan.
So I suggest addition into "Other Github organisations" section ;-)