### PR TITLE
Adding https://cqrs.nu as CQRS resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Resources
 - [en] [slides] https://speakerdeck.com/stijnvnh/cqrs-or-did-you-mean-cars
 - [ru] [article] http://habrahabr.ru/post/146429/
 - [ru] [article] http://habrahabr.ru/post/149464/
+- [en] [website] http://cqrs.nu/
 
 ### Existing php frameworks/libraries integrations, discussions
 


### PR DESCRIPTION
DDD / CQRS articles compilation

From their homepage
> At Edument, we enjoy helping teams apply Domain Driven Design, often through Event Sourcing and CQRS. Here, we've collected resources that are useful for getting productive with the techniques we use and teach.

It is linked to a paid course however :
http://www.edument.se/en/training/Architecture

But I think their FAQ http://cqrs.nu/Faq worth mentioning. Very beginner oriented.

Keep up the good work