### PR TITLE
Add a link to a Symfony implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Also know as Entity-Boundary-Interactor or Ports and Adapters.
 - [en] [article] http://williamdurand.fr/2013/11/13/ddd-with-symfony2-basic-persistence-and-testing/
 - [en] [article] http://williamdurand.fr/2013/08/20/ddd-with-symfony2-making-things-clear/
 - [en] [slides] http://qafoo.com/talks/13_12_symfonycon_domain_events.pdf
+- [en] [article] https://romaricdrigon.github.io/2019/08/09/domain-events
 
 #### Zend Framework 2
 


### PR DESCRIPTION
Romaric Drigon's article about an implementation of Domain Events in a Symfony application.